### PR TITLE
Fix bug getting soundcloud service from clean profile

### DIFF
--- a/components/src/sbSoundCloud.js
+++ b/components/src/sbSoundCloud.js
@@ -185,6 +185,9 @@ function sbSoundCloudSearchService() {
                     .get("ProfD", Ci.nsIFile);
         dir.append("db");
         dir.append("soundcloud");
+        if (!dir.exists()) {
+          dir.create();
+        }
         var uri = ios.newFileURI(dir);
         this._dbq = Cc["@songbirdnest.com/Songbird/DatabaseQuery;1"]
                       .createInstance(Ci.sbIDatabaseQuery);


### PR DESCRIPTION
The call to this._searchService.createTable() was failing for me because the db/soundcloud directory did not exist yet. As a result, most of the stuff that is supposed to happen on startup didn't.

You probably didn't run into this because you already had the directory in your profile from previous work with the soundcloud library db, etc.
